### PR TITLE
Added useNativeDriver: false

### DIFF
--- a/AnimatedCircularProgress.js
+++ b/AnimatedCircularProgress.js
@@ -30,6 +30,7 @@ export default class AnimatedCircularProgress extends Component {
       toValue: this.props.fill,
       tension,
       friction,
+      useNativeDriver: false,
     }).start();
   }
 


### PR DESCRIPTION
- fixes warning "Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false`" on Expo SDK 38 / React Native Version 0.62.2+